### PR TITLE
Fix assertion in search_spec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,12 @@
+###########################
+# Configuration for rubocop
+# in .rubocop.yml
+# Most of these are disabling existing cops, primarily
+# due to a smattering of different styles and loose
+# guidlines for contributions.
+#
+# Any of these may be changed.
+
+
+StringLiterals:
+  Enabled: false

--- a/chapter1/serve
+++ b/chapter1/serve
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+
+#
+# example:
+#  serve public 4001
+#
+# Spin up a quick web server for files in the specified directory (first arg)
+# on the port number given (second arg).
+#
+
+require "webrick"
+
+s = WEBrick::HTTPServer.new(
+  :DocumentRoot => (ARGV[0] || Dir.pwd),
+  :Port => (ARGV[1] || 4000)
+  )
+
+trap('INT') { s.shutdown }
+
+s.start

--- a/chapter1/spec/features/search_spec.rb
+++ b/chapter1/spec/features/search_spec.rb
@@ -5,6 +5,6 @@ describe "My search page" do
     visit("https://google.com")
     fill_in('q', with: "snappy316")
     click_on("Google Search")
-    page.has_content?("twitter.com/snappy316")
+    page.text.must_include("twitter.com/snappy316")
   end
 end


### PR DESCRIPTION
I changed it to `page.text.must_include...`

Question: are `should`'s technically assertions? Like in the "Querying" section of this [capybara cheatsheet](https://gist.github.com/zhengjia/428105)?
